### PR TITLE
[hdEmbree] add distant light support

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -47,6 +47,9 @@ pxr_plugin(hdEmbree
         debugCodes
         implicitSurfaceSceneIndexPlugin
 
+    PRIVATE_HEADERS
+        pxrPbrt/pbrtUtils.h
+
     RESOURCE_FILES
         plugInfo.json
 

--- a/pxr/imaging/plugin/hdEmbree/light.cpp
+++ b/pxr/imaging/plugin/hdEmbree/light.cpp
@@ -97,6 +97,8 @@ HdEmbree_Light::HdEmbree_Light(SdfPath const& id, TfToken const& lightType)
         _lightData.lightVariant = HdEmbree_Cylinder();
     } else if (lightType == HdSprimTypeTokens->diskLight) {
         _lightData.lightVariant = HdEmbree_Disk();
+    } else if (lightType == HdSprimTypeTokens->distantLight) {
+        _lightData.lightVariant = HdEmbree_Distant();
     } else if (lightType == HdSprimTypeTokens->domeLight) {
         _lightData.lightVariant = HdEmbree_Dome();
     } else if (lightType == HdSprimTypeTokens->rectLight) {
@@ -179,6 +181,12 @@ HdEmbree_Light::Sync(HdSceneDelegate *sceneDelegate,
             typedLight = HdEmbree_Disk{
                 sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
                     .GetWithDefault(0.5f),
+            };
+        } else if constexpr (std::is_same_v<T, HdEmbree_Distant>) {
+            typedLight = HdEmbree_Distant{
+                float(GfDegreesToRadians(
+                    sceneDelegate->GetLightParamValue(id, HdLightTokens->angle)
+                        .GetWithDefault(0.53f) / 2.0f)),
             };
         } else if constexpr (std::is_same_v<T, HdEmbree_Dome>) {
             typedLight = HdEmbree_Dome{};

--- a/pxr/imaging/plugin/hdEmbree/light.h
+++ b/pxr/imaging/plugin/hdEmbree/light.h
@@ -23,6 +23,8 @@
 ///   - inputs:color
 ///   - inputs:enableColorTemperature
 ///   - inputs:colorTemperature
+/// - DistantLight
+///   - inputs:angle
 /// - DiskLight
 ///   - inputs:radius
 /// - RectLight
@@ -52,7 +54,6 @@
 /// - Unsupported light types:
 ///   - MeshLightAPI
 ///   - VolumeLightAPI
-///   - DistantLight
 ///   - GeometryLight
 ///   - PortalLight
 ///   - PluginLight
@@ -113,6 +114,11 @@ struct HdEmbree_Disk
     float radius;
 };
 
+struct HdEmbree_Distant
+{
+    float halfAngleRadians;
+};
+
 // Needed for HdEmbree_LightVariant
 struct HdEmbree_Dome
 {};
@@ -132,6 +138,7 @@ using HdEmbree_LightVariant = std::variant<
     HdEmbree_UnknownLight,
     HdEmbree_Cylinder,
     HdEmbree_Disk,
+    HdEmbree_Distant,
     HdEmbree_Dome,
     HdEmbree_Rect,
     HdEmbree_Sphere>;

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
@@ -38,6 +38,7 @@ const TfTokenVector HdEmbreeRenderDelegate::SUPPORTED_SPRIM_TYPES =
     HdPrimTypeTokens->extComputation,
     HdPrimTypeTokens->cylinderLight,
     HdPrimTypeTokens->diskLight,
+    HdPrimTypeTokens->distantLight,
     HdPrimTypeTokens->domeLight,
     HdPrimTypeTokens->rectLight,
     HdPrimTypeTokens->sphereLight,
@@ -341,6 +342,7 @@ HdEmbreeRenderDelegate::CreateSprim(TfToken const& typeId,
     } else if (typeId == HdPrimTypeTokens->extComputation) {
         return new HdExtComputation(sprimId);
     } else if (typeId == HdPrimTypeTokens->light ||
+               typeId == HdPrimTypeTokens->distantLight ||
                typeId == HdPrimTypeTokens->diskLight ||
                typeId == HdPrimTypeTokens->domeLight ||
                typeId == HdPrimTypeTokens->rectLight ||
@@ -364,6 +366,7 @@ HdEmbreeRenderDelegate::CreateFallbackSprim(TfToken const& typeId)
     } else if (typeId == HdPrimTypeTokens->extComputation) {
         return new HdExtComputation(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->light ||
+               typeId == HdPrimTypeTokens->distantLight ||
                typeId == HdPrimTypeTokens->diskLight ||
                typeId == HdPrimTypeTokens->domeLight ||
                typeId == HdPrimTypeTokens->rectLight ||

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -9,6 +9,7 @@
 #include "pxr/imaging/plugin/hdEmbree/config.h"
 #include "pxr/imaging/plugin/hdEmbree/light.h"
 #include "pxr/imaging/plugin/hdEmbree/mesh.h"
+#include "pxr/imaging/plugin/hdEmbree/pxrPbrt/pbrtUtils.h"
 #include "pxr/imaging/plugin/hdEmbree/renderBuffer.h"
 
 #include "pxr/imaging/hd/perfLog.h"
@@ -408,6 +409,51 @@ _EvalLightBasic(HdEmbree_LightData const& light)
 }
 
 _LightSample
+_EvalDistantLight(HdEmbree_LightData const& light, GfVec3f const& position,
+                    float u1, float u2)
+{
+    auto const& distant = std::get<HdEmbree_Distant>(light.lightVariant);
+
+    GfVec3f Le = _EvalLightBasic(light);
+
+    if (distant.halfAngleRadians > 0.0f)
+    {
+        if (light.normalize)
+        {
+            float sinTheta = sinf(distant.halfAngleRadians);
+            Le /= _Sqr(sinTheta) * _pi<float>;
+        }
+
+        // There's an implicit double-negation of the wI direction here
+        GfVec3f localDir = pxr_pbrt::SampleUniformCone(GfVec2f(u1, u2),
+                                              distant.halfAngleRadians);
+        GfVec3f wI = light.xformLightToWorld.TransformDir(localDir);
+        wI.Normalize();
+
+        return _LightSample {
+            Le,
+            wI,
+            std::numeric_limits<float>::max(),
+            pxr_pbrt::InvUniformConePDF(distant.halfAngleRadians)
+        };
+    }
+    else
+    {
+        // delta case, infinite pdf
+        GfVec3f wI = light.xformLightToWorld.TransformDir(
+            GfVec3f(0.0f, 0.0f, 1.0f));
+        wI.Normalize();
+
+        return _LightSample {
+            Le,
+            wI,
+            std::numeric_limits<float>::max(),
+            1.0f,
+        };
+    }
+}
+
+_LightSample
 _EvalAreaLight(HdEmbree_LightData const& light, _ShapeSample const& ss,
                GfVec3f const& position)
 {
@@ -571,6 +617,10 @@ public:
 
     _LightSample operator()(HdEmbree_Dome const& dome) {
         return _EvalDomeLight(_lightData, _normal, _u1, _u2);
+    }
+
+    _LightSample operator()(HdEmbree_Distant const& distant) {
+        return _EvalDistantLight(_lightData, _hitPosition, _u1, _u2);
     }
 
 private:


### PR DESCRIPTION
### Description of Change(s)

Adds support for distant UsdLux lights to the hdEmbree renderer

---------------------

**NOTE**: This chain of PRs was made separate from the PR documenting expected behavior:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3182

---------------------

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement