### PR TITLE
fix: remove double negative in RenderMan error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if (PXR_BUILD_PRMAN_PLUGIN)
     if (EXISTS "${prmanPluginAbsPath}")
         add_subdirectory("${prmanPluginPath}")
     else()
-        message(FATAL_ERROR "No RenderMan plugin not found at "
+        message(FATAL_ERROR "No RenderMan plugin found at "
                 "${prmanPluginAbsPath}. Check client mapping")
     endif()
 endif()


### PR DESCRIPTION
This PR addresses the following issue in `CMakeLists.txt`: remove double negative in RenderMan error message.

## Changes
- `CMakeLists.txt`: remove double negative in RenderMan error message.

## Details
```diff
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-message(FATAL_ERROR "No RenderMan plugin not found at "
-                "${prmanPluginAbsPath}. Check client mapping")
+message(FATAL_ERROR "No RenderMan plugin found at "
+                "${prmanPluginAbsPath}. Check client mapping")
```

## Tests

> Let me know if you want tests added for this fix or not.