### PR TITLE
fix: GetSDKVersion crashes when SDK path contains no version number

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -166,7 +166,11 @@ def GetSDKRoot(context) -> Optional[str]:
 
 def GetSDKVersion(context):
     sdk_basename = os.path.basename(GetSDKRoot(context))
-    return re.search(r'\d+\.\d+', sdk_basename).group()
+    match = re.search(r'\d+\.\d+', sdk_basename)
+    if not match:
+        raise RuntimeError(
+            f"Could not determine SDK version from path: {sdk_basename}")
+    return match.group()
 
 def SetTarget(context):
     targetName = normalizeBuildTarget(context.buildTarget)

--- a/test_apple_utils_sdk.py
+++ b/test_apple_utils_sdk.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import patch
+import apple_utils
+
+
+class TestGetSDKVersion(unittest.TestCase):
+    def test_sdk_version_missing_raises(self):
+        class Ctx:
+            buildTarget = apple_utils.TARGET_IOS
+            cmakeBuildArgs = ""
+
+        with patch.object(apple_utils, 'GetSDKRoot',
+                          return_value='/some/path/XRSimulator.sdk'):
+            with self.assertRaises(RuntimeError):
+                apple_utils.GetSDKVersion(Ctx())
+
+
+if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses the following issue in `build_scripts/apple_utils.py`: GetSDKVersion crashes when SDK path contains no version number.

## Changes
- `build_scripts/apple_utils.py`: GetSDKVersion crashes when SDK path contains no version number.

## Details
```diff
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -1,3 +1,7 @@
-def GetSDKVersion(context):
-    sdk_basename = os.path.basename(GetSDKRoot(context))
-    return re.search(r'\d+\.\d+', sdk_basename).group()
+def GetSDKVersion(context):
+    sdk_basename = os.path.basename(GetSDKRoot(context))
+    match = re.search(r'\d+\.\d+', sdk_basename)
+    if not match:
+        raise RuntimeError(
+            f"Could not determine SDK version from path: {sdk_basename}")
+    return match.group()
```

## Tests
- `build_scripts/test_apple_utils_sdk.py`

```diff
--- /dev/null
+++ build_scripts/test_apple_utils_sdk.py
@@ -0,0 +1,18 @@
+import unittest
+from unittest.mock import patch
+import apple_utils
+
+
+class TestGetSDKVersion(unittest.TestCase):
+    def test_sdk_version_missing_raises(self):
+        class Ctx:
+            buildTarget = apple_utils.TARGET_IOS
+            cmakeBuildArgs = ""
+
+        with patch.object(apple_utils, 'GetSDKRoot',
+                          return_value='/some/path/XRSimulator.sdk'):
+            with self.assertRaises(RuntimeError):
+                apple_utils.GetSDKVersion(Ctx())
+
+
+if __name__ == '__main__':
+    unittest.main()
```